### PR TITLE
Add initial workloads onboarding flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 UPTODATE := .uptodate
 
+$(UPTODATE):
+	touch .uptodate
+
+clean:
+	rm $(UPTODATE)
+
 all: test build
 
 ui: $(UPTODATE)

--- a/pkg/clustersserver/clustersserver.go
+++ b/pkg/clustersserver/clustersserver.go
@@ -223,11 +223,10 @@ func appendSources(sourceType string, k8sObj runtime.Object, res *pb.ListSources
 					Commit: i.Spec.Reference.Commit,
 				},
 				Artifact: &pb.Artifact{
-					Checksum:     artifact.Checksum,
-					Lastupdateat: int32(artifact.LastUpdateTime.Unix()),
-					Path:         artifact.Path,
-					Revision:     artifact.Revision,
-					Url:          artifact.URL,
+					Checksum: artifact.Checksum,
+					Path:     artifact.Path,
+					Revision: artifact.Revision,
+					Url:      artifact.URL,
 				},
 			})
 		}

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -19,11 +19,11 @@ import Kustomizations from "./pages/Kustomizations";
 import Redirector from "./pages/Redirector";
 import SourceDetail from "./pages/SourceDetail";
 import Sources from "./pages/Sources";
+import WorkloadOnboarding from "./pages/WorkloadOnboarding";
 import Workloads from "./pages/Workloads";
 import WorkloadsDetail from "./pages/WorkloadsDetail";
 
 const AppContainer = styled.div`
-  /* display: flex; */
   width: 100%;
   height: 100%;
   margin: 0 auto;
@@ -40,6 +40,10 @@ const ContentCotainer = styled.div`
   margin: 0 auto;
 `;
 
+const TopNavContainer = styled.div`
+  width: 100%;
+`;
+
 export default function App() {
   return (
     <MuiThemeProvider theme={theme}>
@@ -48,9 +52,9 @@ export default function App() {
         <Router>
           <AppStateProvider>
             <AppContainer>
-              <div style={{ width: "100%" }}>
+              <TopNavContainer>
                 <TopNav />
-              </div>
+              </TopNavContainer>
               <div>
                 <Flex>
                   <NavContainer>
@@ -105,6 +109,11 @@ export default function App() {
                         component={WorkloadsDetail}
                       />
                       <Route exact path={PageRoute.Events} component={Events} />
+                      <Route
+                        exact
+                        path={PageRoute.WorkloadOnboarding}
+                        component={WorkloadOnboarding}
+                      />
                       <Route exact path="*" component={() => <p>404</p>} />
                     </Switch>
                   </ContentCotainer>

--- a/ui/components/CommandLineHint.tsx
+++ b/ui/components/CommandLineHint.tsx
@@ -1,0 +1,27 @@
+import _ from "lodash";
+import * as React from "react";
+import styled from "styled-components";
+
+type Props = {
+  className?: string;
+  lines: string[];
+};
+
+const Styled = (c) => styled(c)`
+  background-color: #2f2f2f;
+  color: white;
+  margin: 0;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 1.2em;
+`;
+
+function CommandLineHint({ className, lines }: Props) {
+  return (
+    <div className={className}>
+      <pre>{_.map(lines, (l) => `${l} \\\n`)}</pre>
+    </div>
+  );
+}
+
+export default Styled(CommandLineHint);

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -15,9 +15,27 @@ type Props = {
   fields: { label: string; value: string | ((k: any) => string) }[];
   rows: any[];
 };
+
+const EmptyRow = styled(TableRow)<{ colSpan: number }>`
+  font-style: italic;
+
+  td {
+    text-align: center;
+  }
+`;
 const Styled = (c) => styled(c)``;
 
 function DataTable({ className, fields, rows }: Props) {
+  const r = _.map(rows, (r, i) => (
+    <TableRow key={i}>
+      {_.map(fields, (f) => (
+        <TableCell key={f.label}>
+          {typeof f.value === "function" ? f.value(r) : r[f.value]}
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
+
   return (
     <div className={className}>
       <TableContainer>
@@ -30,15 +48,15 @@ function DataTable({ className, fields, rows }: Props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {_.map(rows, (r, i) => (
-              <TableRow key={i}>
-                {_.map(fields, (f) => (
-                  <TableCell key={f.label}>
-                    {typeof f.value === "function" ? f.value(r) : r[f.value]}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
+            {r.length > 0 ? (
+              r
+            ) : (
+              <EmptyRow colSpan={fields.length}>
+                <TableCell colSpan={fields.length}>
+                  <span style={{ fontStyle: "italic" }}>No rows</span>
+                </TableCell>
+              </EmptyRow>
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/ui/components/Flex.tsx
+++ b/ui/components/Flex.tsx
@@ -19,6 +19,7 @@ const Styled = (component) => styled(component)`
   ${({ center }) => center && "justify-content: center"};
   ${({ wide }) => wide && "width: 100%"};
   ${({ wrap }) => wrap && "flex-wrap: wrap"};
+  ${({ end }) => end && "justify-content: flex-end"};
 `;
 
 class Flex extends React.PureComponent<Props> {

--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -10,9 +10,9 @@ type Props = {
 
 const Styled = (c) => styled(c)``;
 
-function Link({ className, children, to }: Props) {
+function Link({ className, children, to, ...rest }: Props) {
   return (
-    <RouterLink to={to} className={className}>
+    <RouterLink {...rest} to={to} className={className}>
       {children}
     </RouterLink>
   );

--- a/ui/components/SuggestedAction.tsx
+++ b/ui/components/SuggestedAction.tsx
@@ -1,0 +1,31 @@
+import { Box } from "@material-ui/core";
+import * as React from "react";
+import styled from "styled-components";
+
+type Props = React.PropsWithChildren<{
+  className?: string;
+  title?: string;
+}>;
+
+const Styled = (c) => styled(c)`
+  background-color: #d6d6ff;
+  border: 2px solid #9992ff;
+  border-radius: 2px;
+
+  h4 {
+    margin: 8px 0;
+  }
+`;
+
+function SuggestedAction({ className, children, title }: Props) {
+  return (
+    <div className={className}>
+      <Box m={2}>
+        <h4>Suggested Action: {title}</h4>
+        {children}
+      </Box>
+    </div>
+  );
+}
+
+export default Styled(SuggestedAction);

--- a/ui/components/WorkloadOnboardingHints.tsx
+++ b/ui/components/WorkloadOnboardingHints.tsx
@@ -1,0 +1,271 @@
+import {
+  Box,
+  FormControl,
+  MenuItem,
+  Select,
+  TextField,
+} from "@material-ui/core";
+import _ from "lodash";
+import * as React from "react";
+import styled from "styled-components";
+import { SourceType, useKubernetesContexts } from "../lib/hooks";
+import { clustersClient } from "../lib/util";
+import CommandLineHint from "./CommandLineHint";
+import Flex from "./Flex";
+
+type Props = {
+  className?: string;
+  workloadName: string;
+};
+
+const StyledSelect = styled(Select)``;
+
+const Number = styled.div`
+  border-radius: 50%;
+  background-color: #adadad;
+  height: 40px;
+  width: 40px;
+  margin-right: 16px;
+
+  ${Flex} {
+    height: 100%;
+  }
+`;
+
+const Styled = (c) => styled(c)`
+  input {
+    min-width: 300px;
+  }
+`;
+
+type FormValues = {
+  name: string;
+  sourceUrl: string;
+  yamlPath: string;
+  sourceType: SourceType;
+};
+
+const sourceIsCreated = (
+  sourceName: string,
+  contextName: string,
+  sourceType: SourceType
+) =>
+  clustersClient
+    .listSources({
+      contextname: contextName,
+      namespace: "flux-system",
+      sourcetype: sourceType,
+    })
+    .then((res) => {
+      const s = _.find(res.sources, { name: sourceName });
+
+      return !!s;
+    });
+
+const kustomizationIsCreated = (
+  kustomizationName: string,
+  contextName: string
+) =>
+  clustersClient
+    .listKustomizations({
+      contextname: contextName,
+      namespace: "flux-system",
+    })
+    .then((res) => {
+      const k = _.find(res.kustomizations, { name: kustomizationName });
+
+      return !!k;
+    });
+
+function WorkloadOnboardingHints({ className, workloadName }: Props) {
+  const [sourceCreated, setSourceCreated] = React.useState(false);
+  const [kustomizationCreated, setKustomizationCreated] = React.useState(false);
+
+  const [formValues, setFormValues] = React.useState<FormValues>({
+    name: workloadName,
+    sourceType: SourceType.Git,
+    sourceUrl: "",
+    yamlPath: "./clusters",
+  } as FormValues);
+  const { currentContext } = useKubernetesContexts();
+
+  const sourceCheck = async () => {
+    const created = await sourceIsCreated(
+      formValues.name,
+      currentContext,
+      formValues.sourceType
+    );
+
+    if (created) {
+      setSourceCreated(true);
+    }
+  };
+
+  const kustomizationCheck = async () => {
+    const created = await kustomizationIsCreated(
+      formValues.name,
+      currentContext
+    );
+
+    if (created) {
+      setKustomizationCreated(true);
+    }
+  };
+
+  React.useEffect(() => {
+    // Check for source on initial render
+    sourceCheck();
+
+    let interval;
+    if (!sourceCreated) {
+      // Check every 5 seconds and clear if source is found
+      interval = setInterval(() => {
+        sourceCheck();
+      }, 5000);
+    } else {
+      clearInterval(interval);
+    }
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [sourceCreated]);
+
+  React.useEffect(() => {
+    if (!sourceCreated) {
+      // Don't do anything if a source isn't created yet
+      return;
+    }
+    kustomizationCheck();
+
+    let interval;
+    if (!kustomizationCreated) {
+      interval = setInterval(() => {
+        if (kustomizationCreated) {
+          clearInterval(interval);
+        } else {
+          kustomizationCheck();
+        }
+      }, 5000);
+    } else {
+      clearInterval(interval);
+    }
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [sourceCreated, kustomizationCreated]);
+
+  return (
+    <div className={className}>
+      <Box paddingBottom={4}>
+        <FormControl variant="outlined">
+          <Flex wide>
+            <Box marginBottom={2} marginRight={4}>
+              <TextField
+                variant="outlined"
+                label="Name"
+                value={formValues.name}
+                onChange={(e) =>
+                  setFormValues({ ...formValues, name: e.target.value })
+                }
+              />
+            </Box>
+            <Box marginRight={4}>
+              <StyledSelect
+                onChange={(e) => {
+                  setFormValues({
+                    ...formValues,
+                    sourceType: e.target.value as SourceType,
+                  });
+                }}
+                value={formValues.sourceType}
+              >
+                <MenuItem value={SourceType.Git}>{SourceType.Git}</MenuItem>
+                <MenuItem value={SourceType.Bucket}>
+                  {SourceType.Bucket}
+                </MenuItem>
+                <MenuItem value={SourceType.Helm}>{SourceType.Helm}</MenuItem>
+              </StyledSelect>
+            </Box>
+          </Flex>
+          <Flex>
+            <Box marginRight={4}>
+              <TextField
+                variant="outlined"
+                label="Source URL"
+                value={formValues.sourceUrl}
+                onChange={(e) =>
+                  setFormValues({ ...formValues, sourceUrl: e.target.value })
+                }
+              />
+            </Box>
+            <Box marginRight={4}>
+              <TextField
+                variant="outlined"
+                label="Clusters YAML Path"
+                value={formValues.yamlPath}
+                onChange={(e) =>
+                  setFormValues({ ...formValues, yamlPath: e.target.value })
+                }
+              />
+            </Box>
+          </Flex>
+        </FormControl>
+      </Box>
+
+      <div>
+        <Flex align>
+          <Number style={{ backgroundColor: sourceCreated ? "green" : "gray" }}>
+            <Flex className="full-height" align center>
+              1
+            </Flex>
+          </Number>
+          <h4>Create a source</h4>
+        </Flex>
+        <div>
+          <CommandLineHint
+            lines={[
+              `flux create source ${
+                formValues.sourceType || `<source type>`
+              } ${workloadName}`,
+              `  --url=${formValues.sourceUrl || `<source url>`}`,
+              `  --branch=master`,
+              `  --interval=30s`,
+              `  --export > ${
+                formValues.yamlPath || `<yaml path>`
+              }/${workloadName}-source.yaml`,
+            ]}
+          />
+        </div>
+      </div>
+      <div>
+        <Flex align>
+          <Number>
+            <Flex align center>
+              2
+            </Flex>
+          </Number>
+          <h4>Create a Kustomization</h4>
+        </Flex>
+        <div>
+          <CommandLineHint
+            lines={[
+              `flux create kustomization ${workloadName}`,
+              `  --source=${workloadName}`,
+              `  --path="./kustomize"`,
+              `  --prune=true`,
+              `  --validation=client`,
+              `  --interval=5m`,
+              `  --export > ${
+                formValues.yamlPath || `<yaml path>`
+              }/${workloadName}-kustomization.yaml`,
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Styled(WorkloadOnboardingHints);

--- a/ui/lib/util.ts
+++ b/ui/lib/util.ts
@@ -53,6 +53,7 @@ export enum PageRoute {
   Workloads = "/workloads",
   WorkloadDetail = "/workloads_detail",
   Events = "/events",
+  WorkloadOnboarding = "/workloads_onboarding",
   Error = "/error",
 }
 
@@ -71,6 +72,7 @@ export const getNavValue = (currentPage: any): PageRoute | boolean => {
 
     case "workloads":
     case "workloads_detail":
+    case "workloads_onboarding":
       return PageRoute.Workloads;
 
     case "events":

--- a/ui/pages/KustomizationDetail.tsx
+++ b/ui/pages/KustomizationDetail.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Breadcrumbs,
   Button,
   CircularProgress,
   Table,
@@ -15,6 +16,7 @@ import styled from "styled-components";
 import Flex from "../components/Flex";
 import KeyValueTable from "../components/KeyValueTable";
 import Link from "../components/Link";
+import Page from "../components/Page";
 import Panel from "../components/Panel";
 import {
   useKubernetesContexts,
@@ -29,7 +31,11 @@ type Props = {
   className?: string;
 };
 
-const Styled = (c) => styled(c)``;
+const Styled = (c) => styled(c)`
+  .MuiBreadcrumbs-root {
+    width: 100%;
+  }
+`;
 
 const infoFields = [
   "sourceref",
@@ -107,21 +113,33 @@ function KustomizationDetail({ className }: Props) {
   };
 
   return (
-    <div className={className}>
-      <Box m={2}>
-        <Flex align center wide>
+    <Page className={className}>
+      <Flex align wide>
+        <Breadcrumbs>
+          <Link
+            to={formatURL(
+              PageRoute.Kustomizations,
+              currentContext,
+              currentNamespace
+            )}
+          >
+            <h2>Kustomizations</h2>
+          </Link>
           <Flex wide>
             <h2>{kustomizationDetail.name}</h2>
           </Flex>
-          <Button
-            onClick={handleSyncClicked}
-            color="primary"
-            disabled={syncing}
-            variant="contained"
-          >
-            {syncing ? <CircularProgress size={24} /> : "Sync"}
-          </Button>
-        </Flex>
+        </Breadcrumbs>
+        <Button
+          onClick={handleSyncClicked}
+          color="primary"
+          disabled={syncing}
+          variant="contained"
+        >
+          {syncing ? <CircularProgress size={24} /> : "Sync"}
+        </Button>
+      </Flex>
+
+      <Box marginBottom={2}>
         <Panel title="Info">
           <KeyValueTable
             columns={4}
@@ -131,7 +149,7 @@ function KustomizationDetail({ className }: Props) {
         </Panel>
       </Box>
 
-      <Box m={2}>
+      <Box marginBottom={2}>
         <Panel title="Conditions">
           <TableContainer>
             <Table>
@@ -161,7 +179,7 @@ function KustomizationDetail({ className }: Props) {
           </TableContainer>
         </Panel>
       </Box>
-      <Box m={2}>
+      <Box marginBottom={2}>
         <Panel title="Related Workloads">
           {_.map(workloads, (w) => {
             return (
@@ -181,7 +199,7 @@ function KustomizationDetail({ className }: Props) {
           })}
         </Panel>
       </Box>
-    </div>
+    </Page>
   );
 }
 

--- a/ui/pages/KustomizationDetail.tsx
+++ b/ui/pages/KustomizationDetail.tsx
@@ -181,22 +181,28 @@ function KustomizationDetail({ className }: Props) {
       </Box>
       <Box marginBottom={2}>
         <Panel title="Related Workloads">
-          {_.map(workloads, (w) => {
-            return (
-              <div key={w.name}>
-                <Link
-                  to={formatURL(
-                    PageRoute.WorkloadDetail,
-                    currentContext,
-                    w.namespace,
-                    { workloadId: w.name }
-                  )}
-                >
-                  {w.name}
-                </Link>
-              </div>
-            );
-          })}
+          {_.map(
+            _.filter(workloads, {
+              kustomizationrefname: kustomizationDetail.name,
+              kustomizationrefnamespace: kustomizationDetail.namespace,
+            }),
+            (w) => {
+              return (
+                <div key={w.name}>
+                  <Link
+                    to={formatURL(
+                      PageRoute.WorkloadDetail,
+                      currentContext,
+                      w.namespace,
+                      { workloadId: w.name }
+                    )}
+                  >
+                    {w.name}
+                  </Link>
+                </div>
+              );
+            }
+          )}
         </Panel>
       </Box>
     </Page>

--- a/ui/pages/SourceDetail.tsx
+++ b/ui/pages/SourceDetail.tsx
@@ -1,12 +1,15 @@
-import { Box } from "@material-ui/core";
+import { Box, Breadcrumbs } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import ConditionsTable from "../components/ConditionsTable";
 import Flex from "../components/Flex";
 import KeyValueTable from "../components/KeyValueTable";
+import Link from "../components/Link";
+import Page from "../components/Page";
 import Panel from "../components/Panel";
 import { useKubernetesContexts, useNavigation, useSources } from "../lib/hooks";
+import { formatURL, PageRoute } from "../lib/util";
 
 type Props = {
   className?: string;
@@ -61,11 +64,18 @@ function SourceDetail({ className }: Props) {
   const providerUrl = convertRefURLToGitProvider(sourceDetail.url);
 
   return (
-    <div className={className}>
+    <Page className={className}>
       <Box m={2}>
-        <Flex wide>
-          <h2>{sourceDetail.name}</h2>
-        </Flex>
+        <Breadcrumbs>
+          <Link
+            to={formatURL(PageRoute.Sources, currentContext, currentNamespace)}
+          >
+            <h2>Sources</h2>
+          </Link>
+          <Flex wide>
+            <h2>{sourceDetail.name}</h2>
+          </Flex>
+        </Breadcrumbs>
         <Panel title="Info">
           <KeyValueTable
             columns={2}
@@ -112,7 +122,7 @@ function SourceDetail({ className }: Props) {
           <ConditionsTable conditions={sourceDetail.conditions} />
         </Panel>
       </Box>
-    </div>
+    </Page>
   );
 }
 

--- a/ui/pages/WorkloadOnboarding.tsx
+++ b/ui/pages/WorkloadOnboarding.tsx
@@ -1,0 +1,54 @@
+import { Breadcrumbs } from "@material-ui/core";
+import _ from "lodash";
+import * as React from "react";
+import styled from "styled-components";
+import Flex from "../components/Flex";
+import Link from "../components/Link";
+import Page from "../components/Page";
+import WorkloadOnboardingHints from "../components/WorkloadOnboardingHints";
+import {
+  useKubernetesContexts,
+  useNavigation,
+  useWorkloads,
+} from "../lib/hooks";
+import { Workload } from "../lib/rpc/clusters";
+import { formatURL, PageRoute } from "../lib/util";
+
+type Props = {
+  className?: string;
+};
+const Styled = (c) => styled(c)``;
+
+function WorkloadOnboarding({ className }: Props) {
+  const { query } = useNavigation();
+  const { currentContext, currentNamespace } = useKubernetesContexts();
+  const workloads = useWorkloads(currentContext, currentNamespace);
+
+  const workloadDetail = _.find(workloads, {
+    name: query.workloadId,
+  }) as Workload;
+
+  if (!workloadDetail) {
+    return null;
+  }
+
+  return (
+    <Page className={className}>
+      <Breadcrumbs>
+        <Link
+          to={formatURL(PageRoute.Workloads, currentContext, currentNamespace)}
+        >
+          <Flex wide>
+            <h2>Workloads</h2>
+          </Flex>
+        </Link>
+        <h2>{workloadDetail.name}</h2>
+        <h2>Add Workload</h2>
+      </Breadcrumbs>
+      {/* This is its own component to make the hook initial state easier to understand */}
+      <WorkloadOnboardingHints workloadName={workloadDetail.name} />
+    </Page>
+  );
+}
+
+export default Styled(WorkloadOnboarding);

--- a/ui/pages/Workloads.tsx
+++ b/ui/pages/Workloads.tsx
@@ -65,7 +65,19 @@ function Workloads({ className }: Props) {
             ...fields,
             {
               label: "",
-              value: () => <Button>Configure</Button>,
+              value: (w: Workload) => (
+                <Link
+                  style={{ textDecoration: "none" }}
+                  to={formatURL(
+                    PageRoute.WorkloadOnboarding,
+                    currentContext,
+                    currentNamespace,
+                    { workloadId: w.name }
+                  )}
+                >
+                  <Button variant="contained">Add to Flux</Button>
+                </Link>
+              ),
             },
           ]}
           rows={_.filter(workloads, (w) => w.kustomizationrefname === "")}

--- a/ui/pages/Workloads.tsx
+++ b/ui/pages/Workloads.tsx
@@ -1,8 +1,12 @@
+import { Box, Button } from "@material-ui/core";
+import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import DataTable from "../components/DataTable";
 import Flex from "../components/Flex";
 import Link from "../components/Link";
+import Page from "../components/Page";
+import Panel from "../components/Panel";
 import { useKubernetesContexts, useWorkloads } from "../lib/hooks";
 import { Workload } from "../lib/rpc/clusters";
 import { formatURL, PageRoute } from "../lib/util";
@@ -36,15 +40,38 @@ function Workloads({ className }: Props) {
         </Link>
       ),
     },
+    {
+      label: "Namespace",
+      value: "namespace",
+    },
   ];
 
   return (
-    <div className={className}>
+    <Page className={className}>
       <Flex wide>
         <h2>Workloads</h2>
       </Flex>
-      <DataTable fields={fields} rows={workloads} />
-    </div>
+      <Box marginBottom={2}>
+        <Panel title="Flux Enabled Workloads">
+          <DataTable
+            fields={fields}
+            rows={_.filter(workloads, (w) => w.kustomizationrefname !== "")}
+          />
+        </Panel>
+      </Box>
+      <Panel title="Non-flux Workloads">
+        <DataTable
+          fields={[
+            ...fields,
+            {
+              label: "",
+              value: () => <Button>Configure</Button>,
+            },
+          ]}
+          rows={_.filter(workloads, (w) => w.kustomizationrefname === "")}
+        />
+      </Panel>
+    </Page>
   );
 }
 

--- a/ui/pages/WorkloadsDetail.tsx
+++ b/ui/pages/WorkloadsDetail.tsx
@@ -1,7 +1,8 @@
-import { Box } from "@material-ui/core";
+import { Box, Breadcrumbs } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
+import Flex from "../components/Flex";
 import KeyValueTable from "../components/KeyValueTable";
 import Link from "../components/Link";
 import Page from "../components/Page";
@@ -33,47 +34,56 @@ function WorkloadsDetail({ className }: Props) {
   }
 
   return (
-    <div className={className}>
-      <Page>
-        <h2>{workloadDetail.name}</h2>
-        <Panel title="Info">
-          <KeyValueTable
-            columns={[2]}
-            pairs={[
-              {
-                key: "Reconciled By",
-                value: (
-                  <Link
-                    to={formatURL(
-                      PageRoute.KustomizationDetail,
-                      currentContext,
-                      workloadDetail.kustomizationrefnamespace,
-                      { kustomizationId: workloadDetail.kustomizationrefname }
-                    )}
-                  >
-                    {workloadDetail.kustomizationrefname}
-                  </Link>
-                ),
-              },
-            ]}
-          ></KeyValueTable>
+    <Page className={className}>
+      <Breadcrumbs>
+        <Link
+          to={formatURL(PageRoute.Workloads, currentContext, currentNamespace)}
+        >
+          <Flex wide>
+            <h2>Workloads</h2>
+          </Flex>
+        </Link>
+        ,<h2>{workloadDetail.name}</h2>,
+      </Breadcrumbs>
+      <Panel title="Info">
+        <KeyValueTable
+          columns={[2]}
+          pairs={[
+            {
+              key: "Reconciled By",
+              value: workloadDetail.kustomizationrefname ? (
+                <Link
+                  to={formatURL(
+                    PageRoute.KustomizationDetail,
+                    currentContext,
+                    workloadDetail.kustomizationrefnamespace,
+                    { kustomizationId: workloadDetail.kustomizationrefname }
+                  )}
+                >
+                  {workloadDetail.kustomizationrefname}
+                </Link>
+              ) : (
+                "-"
+              ),
+            },
+          ]}
+        ></KeyValueTable>
+      </Panel>
+      <Box paddingTop={2}>
+        <Panel title="Containers">
+          {_.map(workloadDetail.podtemplate.containers, (c) => (
+            <KeyValueTable
+              key={c.name}
+              columns={2}
+              pairs={[
+                { key: "Name", value: c.name },
+                { key: "Image", value: c.image },
+              ]}
+            ></KeyValueTable>
+          ))}
         </Panel>
-        <Box paddingTop={2}>
-          <Panel title="Containers">
-            {_.map(workloadDetail.podtemplate.containers, (c) => (
-              <KeyValueTable
-                key={c.name}
-                columns={2}
-                pairs={[
-                  { key: "Name", value: c.name },
-                  { key: "Image", value: c.image },
-                ]}
-              ></KeyValueTable>
-            ))}
-          </Panel>
-        </Box>
-      </Page>
-    </div>
+      </Box>
+    </Page>
   );
 }
 

--- a/ui/pages/WorkloadsDetail.tsx
+++ b/ui/pages/WorkloadsDetail.tsx
@@ -1,4 +1,4 @@
-import { Box, Breadcrumbs } from "@material-ui/core";
+import { Box, Breadcrumbs, Button } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
@@ -7,6 +7,7 @@ import KeyValueTable from "../components/KeyValueTable";
 import Link from "../components/Link";
 import Page from "../components/Page";
 import Panel from "../components/Panel";
+import SuggestedAction from "../components/SuggestedAction";
 import {
   useKubernetesContexts,
   useNavigation,
@@ -14,14 +15,13 @@ import {
 } from "../lib/hooks";
 import { Workload } from "../lib/rpc/clusters";
 import { formatURL, PageRoute } from "../lib/util";
-
 type Props = {
   className?: string;
 };
 const Styled = (c) => styled(c)``;
 
 function WorkloadsDetail({ className }: Props) {
-  const { query } = useNavigation();
+  const { query, navigate } = useNavigation();
   const { currentContext, currentNamespace } = useKubernetesContexts();
   const workloads = useWorkloads(currentContext, currentNamespace);
 
@@ -45,31 +45,33 @@ function WorkloadsDetail({ className }: Props) {
         </Link>
         ,<h2>{workloadDetail.name}</h2>,
       </Breadcrumbs>
-      <Panel title="Info">
-        <KeyValueTable
-          columns={[2]}
-          pairs={[
-            {
-              key: "Reconciled By",
-              value: workloadDetail.kustomizationrefname ? (
-                <Link
-                  to={formatURL(
-                    PageRoute.KustomizationDetail,
-                    currentContext,
-                    workloadDetail.kustomizationrefnamespace,
-                    { kustomizationId: workloadDetail.kustomizationrefname }
-                  )}
-                >
-                  {workloadDetail.kustomizationrefname}
-                </Link>
-              ) : (
-                "-"
-              ),
-            },
-          ]}
-        ></KeyValueTable>
-      </Panel>
-      <Box paddingTop={2}>
+      <Box marginBottom={2}>
+        <Panel title="Info">
+          <KeyValueTable
+            columns={[2]}
+            pairs={[
+              {
+                key: "Reconciled By",
+                value: workloadDetail.kustomizationrefname ? (
+                  <Link
+                    to={formatURL(
+                      PageRoute.KustomizationDetail,
+                      currentContext,
+                      workloadDetail.kustomizationrefnamespace,
+                      { kustomizationId: workloadDetail.kustomizationrefname }
+                    )}
+                  >
+                    {workloadDetail.kustomizationrefname}
+                  </Link>
+                ) : (
+                  "-"
+                ),
+              },
+            ]}
+          ></KeyValueTable>
+        </Panel>
+      </Box>
+      <Box marginBottom={2}>
         <Panel title="Containers">
           {_.map(workloadDetail.podtemplate.containers, (c) => (
             <KeyValueTable
@@ -79,10 +81,32 @@ function WorkloadsDetail({ className }: Props) {
                 { key: "Name", value: c.name },
                 { key: "Image", value: c.image },
               ]}
-            ></KeyValueTable>
+            />
           ))}
         </Panel>
       </Box>
+      {!workloadDetail.kustomizationrefname && (
+        <Box marginBottom={2}>
+          <SuggestedAction title="Add this workload to flux">
+            <Flex wide center>
+              <Button
+                onClick={() =>
+                  navigate(
+                    PageRoute.WorkloadOnboarding,
+                    currentContext,
+                    currentNamespace,
+                    { workloadId: workloadDetail.name }
+                  )
+                }
+                variant="contained"
+                color="primary"
+              >
+                Add Workload
+              </Button>
+            </Flex>
+          </SuggestedAction>
+        </Box>
+      )}
     </Page>
   );
 }


### PR DESCRIPTION
Adds a baseline view for helping users onboard their workloads into Flux. Very much a first pass and WIP:
![Screenshot from 2021-03-12 11-38-48](https://user-images.githubusercontent.com/2802257/110990154-cbbc2380-8327-11eb-8fbe-6fff692831ff.png)

![Screenshot from 2021-03-12 11-38-59](https://user-images.githubusercontent.com/2802257/110990171-d1b20480-8327-11eb-9fa5-f24f047d79f1.png)
