### PR TITLE
Add bandaid fix for typescript protobuf enums 

### DIFF
--- a/ui/lib/hooks.ts
+++ b/ui/lib/hooks.ts
@@ -99,6 +99,20 @@ export enum SourceType {
   Git = "git",
   Bucket = "bucket",
   Helm = "helm",
+  Chart = "chart",
+}
+
+function convertSourceTypeToInt(s: SourceType) {
+  switch (s) {
+    case SourceType.Git:
+      return 0;
+    case SourceType.Bucket:
+      return 1;
+    case SourceType.Helm:
+      return 2;
+    case SourceType.Chart:
+      return 3;
+  }
 }
 
 type SourceData = {
@@ -127,7 +141,8 @@ export function useSources(
       clustersClient.listSources({
         contextname: currentContext,
         namespace: formatAPINamespace(currentNamespace),
-        sourcetype: s,
+        // @ts-ignore
+        sourcetype: convertSourceTypeToInt(s),
       })
     );
 


### PR DESCRIPTION
Fixes #21 

Our code-gen library does not create `enum`s the way I had expected. This is a quick fix; a more permanent solution will  be to add `enum` support to the code-gen library. https://github.com/larrymyers/protoc-gen-twirp_typescript/issues/61