### PR TITLE
Add release steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Build Assets
+        run: make assets
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Install NPM Modules
+        run: npm ci
       - name: Build Assets
         run: make build
       - name: Run GoReleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.16
       - name: Build Assets
-        run: make assets
+        run: make build
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: release
 
 on:
-  pull_request:
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: release
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,26 +1,49 @@
-# This is an example .goreleaser.yml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
     - go generate ./...
 dist: bin
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - <<: &build_defaults
+      binary: webui
+      main: main.go
+      ldflags:
+        - -s -w -X main.VERSION={{ .Version }}
+      env:
+        - CGO_ENABLED=0
+    id: linux
     goos:
       - linux
-      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
+  - <<: *build_defaults
+    id: darwin
+    goos:
       - darwin
+    goarch:
+      - amd64
+      - arm64
+  - <<: *build_defaults
+    id: windows
+    goos:
+      - windows
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: nix
+    builds: [linux, darwin]
+    format: tar.gz
+    files:
+      - none*
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: windows
+    builds: [windows]
+    format: zip
+    files:
+      - none*
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
 dist: bin
 builds:
   - <<: &build_defaults
-      binary: webui
+      binary: flux_webui
       main: main.go
       ldflags:
         - -s -w -X main.VERSION={{ .Version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,33 @@
+# This is an example .goreleaser.yml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+dist: bin
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
 dist: bin
 builds:
   - <<: &build_defaults
-      binary: flux_webui
+      binary: flux-webui
       main: main.go
       ldflags:
         - -s -w -X main.VERSION={{ .Version }}

--- a/tools/tag-release.sh
+++ b/tools/tag-release.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Pulled and modified from this link:
+# https://gist.github.com/devster/b91b97ebbca4db4d02b84337b2a3d933
+
+# Script to simplify the release flow.
+# 1) Fetch the current release version
+# 2) Increase the version (major, minor, patch)
+# 3) Add a new git tag
+# 4) Push the tag
+
+# Parse command line options.
+while getopts ":Mmpd" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+    d ) dry=true;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+# Display usage
+if [ -z $major ] && [ -z $minor ] && [ -z $patch ];
+then
+  echo "usage: $(basename $0) [Mmp] [message]"
+  echo ""
+  echo "  -d Dry run"
+  echo "  -M for a major release"
+  echo "  -m for a minor release"
+  echo "  -p for a patch release"
+  echo ""
+  echo " Example: release -p \"Some fix\""
+  echo " means create a patch release with the message \"Some fix\""
+  exit 1
+fi
+
+# 1) Fetch the current release version
+
+echo "Fetch tags"
+git fetch --prune --tags
+
+version=$(git describe --abbrev=0 --tags)
+version=${version:1} # Remove the v in the tag v0.37.10 for example
+
+echo "Current version: $version"
+
+# 2) Increase version number
+
+# Build array from version string.
+
+a=( ${version//./ } )
+
+# Increment version numbers as requested.
+
+if [ ! -z $major ]
+then
+  ((a[0]++))
+  a[1]=0
+  a[2]=0
+fi
+
+if [ ! -z $minor ]
+then
+  ((a[1]++))
+  a[2]=0
+fi
+
+if [ ! -z $patch ]
+then
+  ((a[2]++))
+fi
+
+next_version="${a[0]}.${a[1]}.${a[2]}"
+
+msg="$1"
+
+branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+
+# If its a dry run, just display the new release version number
+if [ ! -z $dry ]
+then
+  echo "Tag message: $msg"
+  echo "Next version: v$next_version"
+else
+  # If a command fails, exit the script
+  set -e
+
+  # Push master
+  git push origin $branch
+
+  # If it's not a dry run, let's go!
+  # 3) Add git tag
+  echo "Add git tag v$next_version with message: $msg"
+  git tag -s -a "v$next_version" -m "$msg"
+
+  # 4) Push the new tag
+
+  echo "Push the tag"
+  git push --tags origin $branch
+
+  echo -e "\e[32mRelease done: $next_version\e[0m"
+fi


### PR DESCRIPTION
Closes #38 

Adds a job to create releases when new tags are pushed. I looked at the flux2 configuration for reference, but much of that does not apply to this project (ie docker and brew builds), so this is closer to a default `goreleaser` config.