### PR TITLE
Fix namespace selector and add test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "watch": "jest --runInBand --watch"
   },
   "jest": {
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "moduleNameMapper": {
+      "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/ui/lib/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/ui/lib/fileMock.js"
+    }
   },
   "dependencies": {
     "@babel/preset-env": "^7.13.8",

--- a/ui/components/AppStateProvider.tsx
+++ b/ui/components/AppStateProvider.tsx
@@ -45,7 +45,7 @@ export default function AppStateProvider({ clustersClient, ...props }) {
     });
   };
 
-  const query = qs.parse(location.pathname);
+  const query = qs.parse(location.search);
 
   const getNamespaces = (ctx) => {
     clustersClient.listNamespacesForContext({ contextname: ctx }).then(

--- a/ui/components/TopNav.tsx
+++ b/ui/components/TopNav.tsx
@@ -90,9 +90,13 @@ function TopNav({ className }: Props) {
         <NavWrapper column center wide>
           <Flex center>
             <FormControl variant="outlined">
-              <InputLabel id="context-selector">Context</InputLabel>
+              <InputLabel htmlFor="context-select" id="context-select-label">
+                Context
+              </InputLabel>
               {currentContext && contexts.length > 0 && (
                 <Select
+                  labelId="context-select-label"
+                  id="context-select"
                   onChange={(ev) => {
                     const nextCtx = ev.target.value as string;
                     // setCurrentContext(nextCtx);
@@ -103,8 +107,6 @@ function TopNav({ className }: Props) {
                     );
                   }}
                   value={currentContext}
-                  id="context-selector"
-                  label="Contexts"
                 >
                   {_.map(contexts, (c) => (
                     <MenuItem value={c.name || ""} key={c.name}>
@@ -116,7 +118,7 @@ function TopNav({ className }: Props) {
             </FormControl>
             <FormControl variant="outlined">
               <InputLabel id="namespaces-selector">Namespace</InputLabel>
-              {currentNamespace && namespaces && (
+              {currentNamespace && namespaces && namespaces.length > 0 && (
                 <Select
                   onChange={(ev) => {
                     const nextNs = (ev.target.value === allNamespaces

--- a/ui/components/__tests__/TopNav.test.tsx
+++ b/ui/components/__tests__/TopNav.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import "jest-styled-components";
+import { stubbedClustersResponses, withContext } from "../../lib/test-utils";
+import TopNav from "../TopNav";
+
+describe("TopNav", () => {
+  let container;
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  describe("snapshots", () => {
+    it("renders", async () => {
+      const url = "/?context=my-context&namespace=default";
+
+      const tree = render(withContext(TopNav, url, stubbedClustersResponses));
+      expect((await screen.findByText("my-context")).textContent).toBeTruthy();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  it("sets the current context", async () => {
+    const url = "/?context=my-context&namespace=default";
+
+    render(withContext(TopNav, url, stubbedClustersResponses));
+
+    const input = await screen.findByDisplayValue("my-context");
+
+    expect(input).toBeTruthy();
+  });
+  it("sets the current namespace", async () => {
+    const ns = "some-ns";
+    const url = `/?context=my-context&namespace=${ns}`;
+
+    render(
+      withContext(TopNav, url, {
+        ...stubbedClustersResponses,
+        listNamespacesForContext: { namespaces: [ns] },
+      })
+    );
+
+    const input = await screen.findByDisplayValue(ns);
+    expect(input).toBeTruthy();
+  });
+});

--- a/ui/components/__tests__/__snapshots__/TopNav.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/TopNav.test.tsx.snap
@@ -1,0 +1,458 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TopNav snapshots renders 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c2 {
+  padding: 8px;
+}
+
+.c2 img {
+  max-height: 40px;
+}
+
+.c4 {
+  height: 60px;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c0 {
+  padding: 8px 0;
+  background-color: #3570e3;
+  width: 100%;
+}
+
+.c0 .MuiSelect-outlined {
+  border-color: white !important;
+}
+
+.c0 .MuiSelect-outlined input {
+  border-color: white !important;
+}
+
+.c0 .MuiFormControl-root {
+  border-color: white !important;
+  margin-right: 16px;
+}
+
+.c0 .MuiSelect-outlined,
+.c0 label {
+  color: white !important;
+}
+
+.c0 fieldset,
+.c0 fieldset:hover {
+  border-color: #ffffff !important;
+}
+
+.c0 svg {
+  color: white;
+}
+
+.c0 .MuiSelect-select {
+  min-width: 120px;
+}
+
+.c0 label {
+  height: 42px !important;
+  -webkit-transform: translate(14px,14px) scale(1);
+  -ms-transform: translate(14px,14px) scale(1);
+  transform: translate(14px,14px) scale(1);
+}
+
+.c0 .MuiOutlinedInput-root {
+  height: 40px;
+}
+
+<body>
+    <div />
+    <div>
+      <header
+        class="c0"
+      >
+        <div
+          class="c1"
+        >
+          <div>
+            <a
+              class=""
+              href="/sources?context=my-context&namespace=default"
+            >
+              <div
+                class="c2"
+              >
+                <img
+                  src=""
+                />
+              </div>
+            </a>
+          </div>
+          <div
+            class="c3 c4"
+          >
+            <div
+              class="c5"
+            >
+              <div
+                class="MuiFormControl-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                  data-shrink="true"
+                  for="context-select"
+                  id="context-select-label"
+                >
+                  Context
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-labelledby="context-select-label context-select"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="context-select"
+                    role="button"
+                    tabindex="0"
+                  >
+                    my-context
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    tabindex="-1"
+                    value="my-context"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+                    style="padding-left: 8px;"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legend-2"
+                      style="width: 0.01px;"
+                    >
+                      <span>
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <div
+                class="MuiFormControl-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                  data-shrink="true"
+                  id="namespaces-selector"
+                >
+                  Namespace
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+                >
+                  <div
+                    aria-haspopup="listbox"
+                    aria-labelledby="namespaces-selector"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                    id="namespaces-selector"
+                    role="button"
+                    tabindex="0"
+                  >
+                    default
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    class="MuiSelect-nativeInput"
+                    tabindex="-1"
+                    value="default"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                    >
+                      <span>
+                        Namespace
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+    </div>
+  </body>,
+  "container": <div>
+    <header
+      class="sc-eCssSg ICqmJ"
+    >
+      <div
+        class="sc-bdfBwQ jpNQmq"
+      >
+        <div>
+          <a
+            class="sc-gsTCUz"
+            href="/sources?context=my-context&namespace=default"
+          >
+            <div
+              class="sc-dlfnbm jiaSBd"
+            >
+              <img
+                src=""
+              />
+            </div>
+          </a>
+        </div>
+        <div
+          class="sc-bdfBwQ sc-hKgILt eAcQvl bIjoZh"
+        >
+          <div
+            class="sc-bdfBwQ dKXRSB"
+          >
+            <div
+              class="MuiFormControl-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                data-shrink="true"
+                for="context-select"
+                id="context-select-label"
+              >
+                Context
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  aria-labelledby="context-select-label context-select"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  id="context-select"
+                  role="button"
+                  tabindex="0"
+                >
+                  my-context
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="my-context"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+                  style="padding-left: 8px;"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legend-2"
+                    style="width: 0.01px;"
+                  >
+                    <span>
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <div
+              class="MuiFormControl-root"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-filled"
+                data-shrink="true"
+                id="namespaces-selector"
+              >
+                Namespace
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+              >
+                <div
+                  aria-haspopup="listbox"
+                  aria-labelledby="namespaces-selector"
+                  class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input"
+                  id="namespaces-selector"
+                  role="button"
+                  tabindex="0"
+                >
+                  default
+                </div>
+                <input
+                  aria-hidden="true"
+                  class="MuiSelect-nativeInput"
+                  tabindex="-1"
+                  value="default"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+                <fieldset
+                  aria-hidden="true"
+                  class="PrivateNotchedOutline-root-1 MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="PrivateNotchedOutline-legendLabelled-3 PrivateNotchedOutline-legendNotched-4"
+                  >
+                    <span>
+                      Namespace
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/ui/lib/fileMock.js
+++ b/ui/lib/fileMock.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = "";

--- a/ui/lib/hooks/__tests__/hooks.test.tsx
+++ b/ui/lib/hooks/__tests__/hooks.test.tsx
@@ -67,5 +67,23 @@ describe("app hooks", () => {
 
       expect((await screen.findByText("default")).textContent).toBeTruthy();
     });
+    it("sets the current namespace", async () => {
+      const ns = "my-ns";
+      const TestComponent = () => {
+        const { currentNamespace } = useKubernetesContexts();
+
+        return <p>{currentNamespace}</p>;
+      };
+
+      render(
+        withContext(TestComponent, `/?context=my-context&namespace=${ns}`, {
+          listContexts: { contexts: [{ name: "my-context" }] },
+          listNamespacesForContext: { namespaces: [ns] },
+        }),
+        container
+      );
+
+      expect((await screen.findByText(ns)).textContent).toBeTruthy();
+    });
   });
 });

--- a/ui/lib/test-utils.tsx
+++ b/ui/lib/test-utils.tsx
@@ -25,7 +25,7 @@ type ClientOverrides = {
 export function withContext(
   TestComponent,
   simulatedUrl: string,
-  clientOverrides: ClientOverrides
+  clientOverrides?: ClientOverrides
 ) {
   // Don't make the user wire up all the promise stuff to be interface-compliant
   const promisified = _.reduce(

--- a/ui/pages/__tests__/__snapshots__/KustomizationDetail.test.tsx.snap
+++ b/ui/pages/__tests__/__snapshots__/KustomizationDetail.test.tsx.snap
@@ -23,7 +23,7 @@ Object {
               >
                 <a
                   class="sc-gKsewC"
-                  href="/kustomizations?context=my-context&namespace=all"
+                  href="/kustomizations?context=my-context&namespace=default"
                 >
                   <h2>
                     Kustomizations
@@ -65,7 +65,7 @@ Object {
           </button>
         </div>
         <div
-          class="MuiBox-root MuiBox-root-1"
+          class="MuiBox-root MuiBox-root-4"
         >
           <div
             class="sc-pFZIQ"
@@ -105,7 +105,7 @@ Object {
                             >
                               <a
                                 class="sc-gKsewC"
-                                href="/sources_detail?context=my-context&namespace=all&sourceId=my-source&sourceType=git"
+                                href="/sources_detail?context=my-context&namespace=default&sourceId=my-source&sourceType=git"
                               >
                                 my-source
                               </a>
@@ -183,7 +183,7 @@ Object {
           </div>
         </div>
         <div
-          class="MuiBox-root MuiBox-root-2"
+          class="MuiBox-root MuiBox-root-5"
         >
           <div
             class="sc-pFZIQ"
@@ -257,7 +257,7 @@ Object {
           </div>
         </div>
         <div
-          class="MuiBox-root MuiBox-root-3"
+          class="MuiBox-root MuiBox-root-6"
         >
           <div
             class="sc-pFZIQ"
@@ -399,7 +399,7 @@ Object {
             >
               <a
                 class="sc-gKsewC"
-                href="/kustomizations?context=my-context&namespace=all"
+                href="/kustomizations?context=my-context&namespace=default"
               >
                 <h2>
                   Kustomizations
@@ -441,7 +441,7 @@ Object {
         </button>
       </div>
       <div
-        class="MuiBox-root MuiBox-root-1"
+        class="MuiBox-root MuiBox-root-4"
       >
         <div
           class="sc-pFZIQ"
@@ -481,7 +481,7 @@ Object {
                           >
                             <a
                               class="sc-gKsewC"
-                              href="/sources_detail?context=my-context&namespace=all&sourceId=my-source&sourceType=git"
+                              href="/sources_detail?context=my-context&namespace=default&sourceId=my-source&sourceType=git"
                             >
                               my-source
                             </a>
@@ -559,7 +559,7 @@ Object {
         </div>
       </div>
       <div
-        class="MuiBox-root MuiBox-root-2"
+        class="MuiBox-root MuiBox-root-5"
       >
         <div
           class="sc-pFZIQ"
@@ -633,7 +633,7 @@ Object {
         </div>
       </div>
       <div
-        class="MuiBox-root MuiBox-root-3"
+        class="MuiBox-root MuiBox-root-6"
       >
         <div
           class="sc-pFZIQ"


### PR DESCRIPTION
Fixes an issue with namespace navigation. We were parseing `location.pathname` instead of `location.search`