### PR TITLE
fix context listing bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ func initialContexts() (contexts []string, currentCtx string, err error) {
 		return contexts, currentCtx, err
 	}
 
-	for _, c := range rules.Contexts {
-		contexts = append(contexts, c.Cluster)
+	for contextName := range rules.Contexts {
+		contexts = append(contexts, contextName)
 	}
 
 	return contexts, rules.CurrentContext, nil


### PR DESCRIPTION
We were using the wrong field, c.Cluster, which is the cluster name.
The context name is actually the key portion of rules.Contexts map.

Signed-off-by: Chanwit Kaewkasi <chanwit@gmail.com>